### PR TITLE
SafeStream: prevents unnecessary error during register

### DIFF
--- a/src/SafeStream/SafeStream.php
+++ b/src/SafeStream/SafeStream.php
@@ -50,9 +50,16 @@ class SafeStream
 	 */
 	public static function register()
 	{
-		@stream_wrapper_unregister('safe'); // old protocol
+		$registeredProtocols = stream_get_wrappers();
+
+		if(in_array('safe', $registeredProtocols)){
+			@stream_wrapper_unregister('safe'); // old protocol
+		}
 		stream_wrapper_register('safe', __CLASS__);
-		@stream_wrapper_unregister(self::PROTOCOL); // intentionally @
+
+		if(in_array(self::PROTOCOL, $registeredProtocols)){
+			@stream_wrapper_unregister(self::PROTOCOL); // intentionally @
+		}
 		return stream_wrapper_register(self::PROTOCOL, __CLASS__);
 	}
 

--- a/tests/SafeStream/SafeStream.register.phpt
+++ b/tests/SafeStream/SafeStream.register.phpt
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Test: Nette\Utils\SafeStream basic usage.
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+// registration of stream should not produce unnecessary error
+Assert::same(NULL, error_get_last());


### PR DESCRIPTION
The main reason of this changes is that if error during unregistration of stream happens, php remebers it even if it is suppressed. And SafeStream::register is called in composer autoloading process. So whenever is vendor/autoload.php used, it produces that error. Some third party packages displays the last error by error_get_last() function and it's annoying and unnecessary I think and it can be preveted by this fix.