### PR TITLE
added stream_set_option for PHP 7.4 compatibility

### DIFF
--- a/src/SafeStream/SafeStream.php
+++ b/src/SafeStream/SafeStream.php
@@ -281,5 +281,5 @@ class SafeStream
 	public function stream_set_option(int $option, int $arg1 , int $arg2) : bool
 	{
 		return false;
-	}	
+	}
 }

--- a/src/SafeStream/SafeStream.php
+++ b/src/SafeStream/SafeStream.php
@@ -273,4 +273,13 @@ class SafeStream
 		$path = substr($path, strpos($path, ':') + 3);
 		return unlink($path);
 	}
+
+
+	/**
+	 * Does nothing, but since PHP 7.4 needs to be implemented when using wrapper for includes
+	 */
+	public function stream_set_option(int $option, int $arg1 , int $arg2) : bool
+	{
+		return false;
+	}	
 }


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no
- doc PR: not needed

Fix missing implementation of stream_set_option

In PHP 7.4 there is stream_set_option called when using own stream wrapper in include / require statements.
According to https://bugs.php.net/bug.php?id=78375 and https://github.com/php/php-src/commit/8a4171ac457c048e1b05b2d9fc9b74f4816272a0 empty implementation is sufficient.